### PR TITLE
Add query string parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Take a URL and map to functions, parsing params
 import route from 'url-mapper';
 
 const someFunc = function (data) {
-  data // {path: '/foo', params: {id: '123'}, query: {foo: 'bar'}
+  data // {path: '/foo', params: {id: '123'}, query: {foo: 'bar'}}
 };
 
 route(location.origin + '/foo/123', {
   '/foo/:id': someFunc
 });
 ```
-url-mapper passes an object representing the parsed URL to your route callbacks. Given the URL `http://www.bigapp.com/foo/123?bar=baz` and a matching route `/foo/:id`, your callbacks will receive:
+**url-mapper** passes an object representing the parsed URL to your route callbacks. Given the URL `http://www.bigapp.com/foo/123?bar=baz` and a matching route `/foo/:id`, your callbacks will receive:
 ```js
 {
   path: '/foo',
@@ -21,4 +21,4 @@ url-mapper passes an object representing the parsed URL to your route callbacks.
 }
 ```
 
-This library allows you to take a url and map it to functions. It allows dynamic segments. You can pass a full url or just the path. It's not a full routing solution and is designed to be used with other libraries to map urls to functions.
+This library just allows you to map a url to a function. It allows dynamic segments and you can pass a full url or just the path. It's designed to be used with other libraries to manage URLs in your applications.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,20 @@ Take a URL and map to functions, parsing params
 import route from 'url-mapper';
 
 const someFunc = function (data) {
-  data // {path: '/foo', params: {id: '123'}}
+  data // {path: '/foo', params: {id: '123'}, query: {foo: 'bar'}
 };
 
 route(location.origin + '/foo/123', {
   '/foo/:id': someFunc
 });
 ```
+url-mapper passes an object representing the parsed URL to your route callbacks. Given the URL `http://www.bigapp.com/foo/123?bar=baz` and a matching route `/foo/:id`, your callbacks will receive:
+```js
+{
+  path: '/foo',
+  params: {id: 123},
+  query: {bar: 'baz'}
+}
+```
 
-This library allows you to take a url and map it to functions. It allows dynamic segments. You can pass a full url or just the path. To be used with other libraries to map urls to functions.
+This library allows you to take a url and map it to functions. It allows dynamic segments. You can pass a full url or just the path. It's not a full routing solution and is designed to be used with other libraries to map urls to functions.

--- a/index.js
+++ b/index.js
@@ -17,9 +17,14 @@ module.exports = function (url, routes) {
     var route = utils.findMatchingRoute(routes, path);
     var params = utils.parseParams(route, path);
 
+    if (var queryString = location.search) {
+      var query = utils.parseQueryString(queryString.substr(1));
+    }
+
     routes[route]({
       path: path,
-      params: params
+      params: params,
+      query: query
     });
 
 };

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "react": "^0.13.3",
     "webpack": "^1.10.5",
     "webpack-dev-server": "^1.10.1"
+  },
+  "dependencies": {
+    "qs": "^4.0.0"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+var qs = require('qs');
+
 var utils = {
   findMatchingRoute: function (routes, pathname) {
     return Object.keys(routes).filter(function(route) {
@@ -22,6 +24,9 @@ var utils = {
   asRegex: function (route) {
     var regexableRoute = '^' + route.replace(/:(\w+)/g, "(:?\\w+)") + '$';
     return new RegExp(regexableRoute, 'g');
+  },
+  parseQueryString: function(queryString) {
+    return qs.parse(queryString);
   }
 };
 


### PR DESCRIPTION
This pull adds query string parsing via the [qs library](https://github.com/hapijs/qs), which allows for parsing arrays and deeply nested keys into JS objects. Tests should now be green again. I think the rest is pretty straightforward! :smile: 
