### PR TITLE
fix(parse): ensure optional parameters return undefined and not "undefined"

### DIFF
--- a/compileRoute.js
+++ b/compileRoute.js
@@ -34,8 +34,8 @@ function compileRoute (route, options) {
 
       for (var i = 1; i < match.length; ++i) {
         var key = keys[i - 1]
-        var value = decodeURIComponent(match[i])
-        if (value[0] === ':') {
+        var value = match[i] && decodeURIComponent(match[i])
+        if (value && value[0] === ':') {
           result[key] = URLON.parse(value)
         } else {
           result[key] = value

--- a/tests/test.js
+++ b/tests/test.js
@@ -389,6 +389,17 @@ module.exports = {
         test.deepEqual(mapper.parse('/:foo', '/bar#@bar=baz'), { foo: 'bar', bar: 'baz' })
 
         test.done()
+      },
+
+      'should parse optional paramters as undefined': function (test) {
+        var mapper = urlMapper()
+
+        test.deepEqual(mapper.parse('/:foo/:bar?', '/bar/'), {
+          foo: 'bar',
+          bar: undefined
+        })
+
+        test.done()
       }
     }
   }


### PR DESCRIPTION
This is needed so that the optional parameters come through as undefined rather than "undefined" which  decodeURIComponent does.
