### PR TITLE
style: fix standard issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,14 @@
 module.exports = {
   env: {
     browser: true,
-    commonjs: true,
+    commonjs: true
   },
   extends: ['eslint:recommended', 'standard', 'plugin:prettier/recommended', 'prettier'],
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2015
   },
   rules: {
     'no-var': 'off',
-    'prettier/prettier': 'error',
-  },
+    'prettier/prettier': 'error'
+  }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "trailingComma": "es5",
+  "trailingComma": "none",
   "tabWidth": 2,
   "semi": false,
   "singleQuote": true,

--- a/compileRoute.js
+++ b/compileRoute.js
@@ -94,7 +94,7 @@ function compileRoute(route, options) {
       }
 
       return path + (queryString ? querySeparator + queryString : '')
-    },
+    }
   }
 }
 

--- a/example.js
+++ b/example.js
@@ -9,8 +9,8 @@ var object = {
     baz: ['foo', 'bar', 'baz', true, false, undefined, null],
     qux: '',
     quux: null,
-    garply: undefined,
-  },
+    garply: undefined
+  }
 }
 
 var url = urlMapper.stringify('/:foo', object)
@@ -21,6 +21,6 @@ console.log(parsed)
 
 var mapped = urlMapper.map(url, {
   '/:foo': 'one',
-  '/:foo/bar': 'two',
+  '/:foo/bar': 'two'
 })
 console.log(mapped)

--- a/mapper.js
+++ b/mapper.js
@@ -35,7 +35,7 @@ module.exports = function mapper(compileFn, options) {
         return {
           route: route,
           match: match,
-          values: values,
+          values: values
         }
       }
     }
@@ -44,6 +44,6 @@ module.exports = function mapper(compileFn, options) {
   return {
     parse: parse,
     stringify: stringify,
-    map: map,
+    map: map
   }
 }

--- a/tests/urlMapper.test.js
+++ b/tests/urlMapper.test.js
@@ -16,7 +16,7 @@ describe('mapper', function () {
     })
     return {
       parse: parse,
-      stringify: stringify,
+      stringify: stringify
     }
   })
 
@@ -95,7 +95,7 @@ describe('mapper', function () {
     it('should pass route and options arguments to compileFn', function () {
       var options = {}
       var routes = {
-        ':url': {},
+        ':url': {}
       }
       var mapper = Mapper(compileFn, options)
 
@@ -106,7 +106,7 @@ describe('mapper', function () {
     it('should return matched route and parsed values', function () {
       var routes = {
         ':url1': 'match1',
-        ':url2': 'match2',
+        ':url2': 'match2'
       }
       var mapper = Mapper(compileFn)
 
@@ -115,8 +115,8 @@ describe('mapper', function () {
         match: 'match1',
         values: {
           route: ':url1',
-          url: 'url1',
-        },
+          url: 'url1'
+        }
       })
 
       expect(mapper.map('url2', routes)).toEqual({
@@ -124,15 +124,15 @@ describe('mapper', function () {
         match: 'match2',
         values: {
           route: ':url2',
-          url: 'url2',
-        },
+          url: 'url2'
+        }
       })
     })
 
     it('should return only first matched route and parsed values', function () {
       var routes = {
         ':url': 'match1',
-        ':url1': 'match2',
+        ':url1': 'match2'
       }
       var mapper = Mapper(compileFn)
 
@@ -141,8 +141,8 @@ describe('mapper', function () {
         match: 'match1',
         values: {
           route: ':url',
-          url: 'url11',
-        },
+          url: 'url11'
+        }
       })
     })
 
@@ -167,7 +167,7 @@ describe('urlMapper', function () {
 
       expect(mapper.parse('/:foo/:bar', '/bar/baz')).toEqual({
         foo: 'bar',
-        bar: 'baz',
+        bar: 'baz'
       })
     })
 
@@ -176,7 +176,7 @@ describe('urlMapper', function () {
 
       expect(mapper.parse('/:foo/:bar', '/bar/baz?query')).toEqual({
         foo: 'bar',
-        bar: 'baz',
+        bar: 'baz'
       })
     })
 
@@ -185,7 +185,7 @@ describe('urlMapper', function () {
 
       expect(mapper.parse('/:foo/:bar', '/bar/baz#hash')).toEqual({
         foo: 'bar',
-        bar: 'baz',
+        bar: 'baz'
       })
     })
 
@@ -203,7 +203,7 @@ describe('urlMapper', function () {
           foo: 'bar',
           bar: 'baz',
           baz: 'foo',
-          qux: {},
+          qux: {}
         })
       ).toEqual('/bar/baz')
     })
@@ -214,7 +214,7 @@ describe('urlMapper', function () {
         foo: true,
         bar: false,
         baz: 42,
-        qux: null,
+        qux: null
       }
       // URLON-like notation
       var url = '/:true/:false/:42/:null'
@@ -226,7 +226,7 @@ describe('urlMapper', function () {
     it('should properly escape unsafe symbols in segments', function () {
       var mapper = urlMapper()
       var object = {
-        foo: 'foo/?#\'"bar',
+        foo: 'foo/?#\'"bar'
       }
 
       var url = '/foo%2F%3F%23%27%22bar'
@@ -242,7 +242,7 @@ describe('urlMapper', function () {
         mapper.stringify('/:foo', {
           foo: {},
           bar: 'baz',
-          baz: 'foo',
+          baz: 'foo'
         })
       }).toThrow()
     })
@@ -254,7 +254,7 @@ describe('urlMapper', function () {
 
       expect(mapper.parse('/:foo/:bar', '/bar/baz')).toEqual({
         foo: 'bar',
-        bar: 'baz',
+        bar: 'baz'
       })
     })
 
@@ -264,7 +264,7 @@ describe('urlMapper', function () {
       expect(mapper.parse('/:foo/:bar', '/bar/baz?baz=foo')).toEqual({
         foo: 'bar',
         bar: 'baz',
-        baz: 'foo',
+        baz: 'foo'
       })
     })
 
@@ -273,13 +273,13 @@ describe('urlMapper', function () {
 
       expect(mapper.parse('/:foo/:bar', '/bar/baz#hash')).toEqual({
         foo: 'bar',
-        bar: 'baz',
+        bar: 'baz'
       })
 
       expect(mapper.parse('/:foo/:bar', '/bar/baz?baz=foo#hash')).toEqual({
         foo: 'bar',
         bar: 'baz',
-        baz: 'foo',
+        baz: 'foo'
       })
     })
 
@@ -295,7 +295,7 @@ describe('urlMapper', function () {
       expect(
         mapper.stringify('/:foo/:bar', {
           foo: 'bar',
-          bar: 'baz',
+          bar: 'baz'
         })
       ).toEqual('/bar/baz')
     })
@@ -306,7 +306,7 @@ describe('urlMapper', function () {
       expect(
         mapper.stringify('/:foo', {
           foo: 'bar',
-          bar: undefined,
+          bar: undefined
         })
       ).toEqual('/bar')
     })
@@ -320,8 +320,8 @@ describe('urlMapper', function () {
           foo: true,
           bar: 2,
           baz: ['foo', 'bar', 'baz'],
-          e: '',
-        },
+          e: ''
+        }
       }
 
       // we do not test which url it stringified to
@@ -353,7 +353,7 @@ describe('urlMapper', function () {
 
       expect(mapper.parse('/:foo/:bar?', '/bar/')).toEqual({
         foo: 'bar',
-        bar: undefined,
+        bar: undefined
       })
     })
   })


### PR DESCRIPTION
- [x] Fix styling issue about `"trailingComma": "es5"`

The CI of `standard` is currently failing, because this repo doesn't follow the latest rules from `standard`, so we should fix this.
See: https://github.com/standard/standard/issues/1663

In another PR, we should also fix this issue : `url-mapper/index.js:3:1: Unexpected var, use let or const instead.`, it is only a warning currently.
I didn't fix this in this PR, because it would make the PR with too much diff.

To fix this, you only need to run `npx standard --fix`.